### PR TITLE
Add simple web interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Busy with webinterface and MQTT
 
 I integrated in esphome, work like a charm. Check yaml
 
+## Extra webinterface
+
+The firmware now enables the ESPHome `web_server` component. Browse to the
+device IP address to access a simple control panel. A minimal example page is
+provided in [`web/index.html`](web/index.html) which can be uploaded using the
+ESPHome dashboard or served separately.
+
 ![Schematic](Schematic.png)
 
 ![PCB](PCB_WTW.png)

--- a/Wtw.yaml
+++ b/Wtw.yaml
@@ -34,6 +34,12 @@ wifi:
 
 captive_portal:
 
+web_server:
+  port: 80
+  auth:
+    username: "admin"
+    password: "esp32"
+
 time:
   - platform: homeassistant
     id: time_homeassistant

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Brink WTW Control</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 20px; }
+button { padding: 6px 12px; margin: 4px; }
+</style>
+<script>
+function sendCommand(id, state) {
+  fetch('/switch/' + id + '?turn=' + state)
+    .then(res => console.log(id + ' ' + state + ' -> ' + res.status));
+}
+</script>
+</head>
+<body>
+<h1>Brink/Elan Ventilation Control</h1>
+<div>
+  <h2>WTW</h2>
+  <button onclick="sendCommand('relay9','ON')">Positie 4</button>
+  <button onclick="sendCommand('relay1','ON')">Positie 3</button>
+  <button onclick="sendCommand('relay2','ON')">Positie 2</button>
+  <button onclick="sendCommand('position1','ON')">Positie 1</button>
+</div>
+<div>
+  <h2>Elan beneden</h2>
+  <button onclick="sendCommand('relay5','ON')">Positie 4</button>
+  <button onclick="sendCommand('relay4','ON')">Positie 3</button>
+  <button onclick="sendCommand('relay3','ON')">Positie 2</button>
+  <button onclick="sendCommand('elanbenedenp1','ON')">Positie 1</button>
+</div>
+<div>
+  <h2>Elan boven</h2>
+  <button onclick="sendCommand('relay8','ON')">Positie 4</button>
+  <button onclick="sendCommand('relay7','ON')">Positie 3</button>
+  <button onclick="sendCommand('relay6','ON')">Positie 2</button>
+  <button onclick="sendCommand('elanbovenp1','ON')">Positie 1</button>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- enable ESPHome web_server in `Wtw.yaml`
- document the extra interface in README
- add example HTML page under `web/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6847ef1a6f888330b32e9339ac31081d