### PR TITLE
Add optional MQTT support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,17 @@ prefer the Arduino IDE, follow the steps below to build the sketch in
 1. Install the required libraries in the Arduino IDE using the Library Manager:
    - **ESPAsyncWebServer**
    - **AsyncTCP**
+   - **PubSubClient** (only needed when MQTT is enabled)
 2. Open `arduino/BrinkWTW.ino` in the Arduino IDE.
 3. Select an ESP32 board (for example **ESP32 Dev Module**) and upload the
    sketch to your device.
+
+### Enabling MQTT
+
+To compile the sketch with MQTT support, define the `USE_MQTT` flag. The
+simplest way in the Arduino IDE is to add `#define USE_MQTT` near the top of
+`BrinkWTW.ino` before compiling. When the flag is omitted, the sketch is built
+without the MQTT client and no additional libraries are required.
 
 ## Extra webinterface
 

--- a/arduino/BrinkWTW.ino
+++ b/arduino/BrinkWTW.ino
@@ -3,8 +3,28 @@
 #include <ESPAsyncWebServer.h>
 #include <AsyncTCP.h>
 #include <LittleFS.h>
+#ifdef USE_MQTT
+#include <PubSubClient.h>
+
+#ifndef MQTT_HOST
+#define MQTT_HOST "localhost"
+#endif
+
+#ifndef MQTT_PORT
+#define MQTT_PORT 1883
+#endif
+
+WiFiClient mqttWifiClient;
+PubSubClient mqttClient(mqttWifiClient);
+#endif
 
 AsyncWebServer server(80);
+
+#ifdef USE_MQTT
+void initMqtt() {
+  mqttClient.setServer(MQTT_HOST, MQTT_PORT);
+}
+#endif
 
 struct SwitchDef {
   const char *id;
@@ -59,6 +79,10 @@ void setup() {
 
   WiFi.mode(WIFI_AP_STA);
 
+#ifdef USE_MQTT
+  initMqtt();
+#endif
+
   server.on("/sensors", HTTP_GET, [](AsyncWebServerRequest *req){
     // Minimal stub response similar to ESPHome web_server
     String json = "{\"sensors\":[{\"name\":\"WiFi RSSI\",\"value\":" + String(WiFi.RSSI()) + "}]}";
@@ -85,4 +109,7 @@ void setup() {
 }
 
 void loop() {
+#ifdef USE_MQTT
+  mqttClient.loop();
+#endif
 }


### PR DESCRIPTION
## Summary
- add compile-time MQTT client initialization
- mention PubSubClient and USE_MQTT in README

## Testing
- `arduino-cli compile --fqbn esp32:esp32:esp32 arduino/BrinkWTW.ino` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68487a6ef6bc8330a8f795b9b9276767