### PR TITLE
Add gitignore rules for build and hardware files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Arduino build outputs
+*.elf
+*.bin
+
+# LittleFS images
+*littlefs*
+*LittleFS*
+
+# Hardware files generated in pcb/
+pcb/*.zip
+pcb/*.csv
+pcb/*.png


### PR DESCRIPTION
## Summary
- add `.gitignore` to exclude Arduino build outputs, LittleFS images and hardware exports in `pcb/`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684887cc2d2c8330b8553eed45e6d1b6